### PR TITLE
Add style preview flow before full deck generation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react'
 import ApiKeySettings from './components/ApiKeySettings'
-import BackCoverGenerator from './components/BackCoverGenerator'
 import BatchGenerator from './components/BatchGenerator'
 import CardGrid from './components/CardGrid'
 import CardEditor from './components/CardEditor'
 import ComparisonDialog from './components/ComparisonDialog'
+import StylePreviewGenerator from './components/StylePreviewGenerator'
+import { initializeCards } from './data/tarotCards'
 import { loadState, saveState } from './services/localStorage'
 
 function App() {
@@ -13,28 +14,63 @@ function App() {
   const [cards, setCards] = useState([])
   const [selectedCard, setSelectedCard] = useState(null)
   const [comparisonData, setComparisonData] = useState(null)
+  const [stylePrompt, setStylePrompt] = useState('')
+  const [hasConfirmedStyle, setHasConfirmedStyle] = useState(false)
 
   useEffect(() => {
     const state = loadState()
     if (state.apiKey) setApiKey(state.apiKey)
     if (state.backCover) setBackCover(state.backCover)
     if (state.cards) setCards(state.cards)
+    if (state.stylePrompt) setStylePrompt(state.stylePrompt)
+    if (state.hasConfirmedStyle) setHasConfirmedStyle(state.hasConfirmedStyle)
   }, [])
 
   useEffect(() => {
-    saveState({ apiKey, backCover, cards })
-  }, [apiKey, backCover, cards])
+    saveState({ apiKey, backCover, cards, stylePrompt, hasConfirmedStyle })
+  }, [apiKey, backCover, cards, stylePrompt, hasConfirmedStyle])
 
   const handleApiKeyChange = (key) => {
     setApiKey(key)
   }
 
-  const handleBackCoverGenerated = (imageData) => {
-    setBackCover(imageData)
-  }
-
   const handleBatchGenerated = (generatedCards) => {
     setCards(generatedCards)
+  }
+
+  const handlePreviewConfirmed = ({ prompt, backCover: previewBackCover, card }) => {
+    setStylePrompt(prompt)
+    setBackCover(previewBackCover)
+
+    const allCards = initializeCards()
+    const previewIndex = allCards.findIndex(c => c.id === card.id)
+    const previewCard = {
+      ...allCards[previewIndex],
+      image: card.image,
+      previousVersions: [],
+      isGenerating: false
+    }
+
+    const remainingCards = allCards
+      .filter((_, index) => index !== previewIndex)
+      .map(cardItem => ({
+        ...cardItem,
+        image: null,
+        previousVersions: [],
+        isGenerating: false
+      }))
+
+    setCards([previewCard, ...remainingCards])
+    setHasConfirmedStyle(true)
+  }
+
+  const handleResetStyle = () => {
+    setStylePrompt('')
+    setBackCover(null)
+    setCards([])
+    setHasConfirmedStyle(false)
+    setSelectedCard(null)
+    setComparisonData(null)
   }
 
   const handleCardGenerated = (cardId, imageDataUrl, error) => {
@@ -81,17 +117,58 @@ function App() {
 
         {apiKey && (
           <>
-            <BackCoverGenerator
-              apiKey={apiKey}
-              currentBackCover={backCover}
-              onBackCoverGenerated={handleBackCoverGenerated}
-            />
+            {!hasConfirmedStyle ? (
+              <StylePreviewGenerator
+                apiKey={apiKey}
+                onPreviewConfirmed={handlePreviewConfirmed}
+              />
+            ) : (
+              <div className="mb-8 p-6 bg-gray-800 rounded-lg border border-gray-700">
+                <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+                  <div>
+                    <h2 className="text-xl font-semibold text-purple-400 mb-2">Style locked in</h2>
+                    <p className="text-sm text-gray-300 max-w-2xl">
+                      You can now generate the remaining cards in your deck using the confirmed style below. If you want to try a different look, reset the preview and start again.
+                    </p>
+                  </div>
+                  <button
+                    onClick={handleResetStyle}
+                    className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded-lg transition-colors"
+                  >
+                    Reset style preview
+                  </button>
+                </div>
 
-            <BatchGenerator
-              apiKey={apiKey}
-              onBatchGenerated={handleBatchGenerated}
-              onCardGenerated={handleCardGenerated}
-            />
+                <div className="grid md:grid-cols-3 gap-6 mt-6">
+                  <div className="md:col-span-2">
+                    <h3 className="text-sm text-gray-400 mb-2">Style prompt</h3>
+                    <div className="p-4 bg-gray-900 border border-gray-700 rounded-lg text-sm text-gray-200 whitespace-pre-wrap">
+                      {stylePrompt}
+                    </div>
+                  </div>
+                  <div>
+                    <h3 className="text-sm text-gray-400 mb-2">Back cover preview</h3>
+                    <div className="aspect-[2/3] bg-gray-900 rounded-lg border border-gray-700 overflow-hidden flex items-center justify-center">
+                      {backCover ? (
+                        <img src={backCover} alt="Confirmed tarot back cover" className="w-full h-full object-contain" />
+                      ) : (
+                        <p className="text-gray-500 text-center px-2">Back cover not available</p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {hasConfirmedStyle && (
+              <BatchGenerator
+                apiKey={apiKey}
+                prompt={stylePrompt}
+                cards={cards}
+                onBatchGenerated={handleBatchGenerated}
+                onCardGenerated={handleCardGenerated}
+              />
+            )}
 
             <CardGrid
               cards={cards}

--- a/src/components/CardGrid.jsx
+++ b/src/components/CardGrid.jsx
@@ -3,7 +3,7 @@ export default function CardGrid({ cards, backCover, onCardSelect }) {
     return (
       <div className="p-8 bg-gray-800 rounded-lg border border-gray-700 text-center">
         <p className="text-gray-400">
-          No cards generated yet. Use the Batch Generator above to create your tarot deck.
+          No cards generated yet. Generate a style preview above to start building your tarot deck.
         </p>
       </div>
     )

--- a/src/components/StylePreviewGenerator.jsx
+++ b/src/components/StylePreviewGenerator.jsx
@@ -1,0 +1,126 @@
+import { useState } from 'react'
+import { generateImage } from '../services/geminiApi'
+import { initializeCards } from '../data/tarotCards'
+
+export default function StylePreviewGenerator({ apiKey, onPreviewConfirmed, onReset }) {
+  const [prompt, setPrompt] = useState('')
+  const [isGenerating, setIsGenerating] = useState(false)
+  const [error, setError] = useState(null)
+  const [preview, setPreview] = useState(null)
+
+  const handleGeneratePreview = async () => {
+    if (!prompt.trim()) return
+
+    setIsGenerating(true)
+    setError(null)
+
+    try {
+      const allCards = initializeCards()
+      const randomCard = allCards[Math.floor(Math.random() * allCards.length)]
+
+      const backCoverPrompt = `Create a tarot card back cover design. ${prompt}. The design should be mystical, ornate, and symmetrical, suitable for the back of all tarot cards in a deck. IMPORTANT: Create this as a vertical portrait image with a 2:3 aspect ratio (width:height). The entire design should fit within this format without any cropping.`
+
+      const cardPrompt = `${prompt}. Create a tarot card illustration for "${randomCard.name}". The card should be vertically oriented with mystical and symbolic imagery. Focus on achieving the exact style, palette, and rendering quality described above. Create this as a vertical portrait image with a 2:3 aspect ratio (width:height). The entire design should fit within this format without any cropping.`
+
+      const [backCoverImage, cardImage] = await Promise.all([
+        generateImage(apiKey, backCoverPrompt),
+        generateImage(apiKey, cardPrompt)
+      ])
+
+      setPreview({
+        prompt,
+        backCover: backCoverImage,
+        card: {
+          ...randomCard,
+          image: cardImage
+        }
+      })
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setIsGenerating(false)
+    }
+  }
+
+  const handleConfirm = () => {
+    if (preview) {
+      onPreviewConfirmed(preview)
+    }
+  }
+
+  const handleReset = () => {
+    setPreview(null)
+    if (onReset) {
+      onReset()
+    }
+  }
+
+  return (
+    <div className="mb-8 p-6 bg-gray-800 rounded-lg border border-gray-700">
+      <h2 className="text-xl font-semibold mb-4 text-purple-400">Style Preview</h2>
+
+      <div className="space-y-6">
+        <div>
+          <label className="block text-sm text-gray-400 mb-2">
+            Describe the style for your tarot deck
+          </label>
+          <textarea
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            placeholder="E.g., Art Nouveau with ornate borders, soft watercolor textures, muted jewel tones, ethereal lighting..."
+            rows={3}
+            className="w-full px-4 py-2 bg-gray-900 border border-gray-600 rounded-lg focus:outline-none focus:border-purple-500 text-white resize-none"
+            disabled={isGenerating}
+          />
+
+          <button
+            onClick={handleGeneratePreview}
+            disabled={!prompt.trim() || isGenerating}
+            className="mt-4 w-full px-4 py-2 bg-purple-600 hover:bg-purple-700 disabled:bg-gray-600 disabled:cursor-not-allowed rounded-lg transition-colors"
+          >
+            {isGenerating ? 'Generating preview...' : 'Generate Style Preview'}
+          </button>
+        </div>
+
+        {error && (
+          <div className="p-3 bg-red-900/30 border border-red-700 rounded-lg text-red-400 text-sm">
+            {error}
+          </div>
+        )}
+
+        {preview && (
+          <div className="grid md:grid-cols-2 gap-6">
+            <div>
+              <h3 className="text-lg font-semibold text-purple-300 mb-3">Back Cover</h3>
+              <div className="aspect-[2/3] bg-gray-900 rounded-lg border border-gray-600 overflow-hidden flex items-center justify-center">
+                <img src={preview.backCover} alt="Tarot back cover preview" className="w-full h-full object-contain" />
+              </div>
+            </div>
+
+            <div>
+              <h3 className="text-lg font-semibold text-purple-300 mb-3">Sample Card — {preview.card.name}</h3>
+              <div className="aspect-[2/3] bg-gray-900 rounded-lg border border-gray-600 overflow-hidden flex items-center justify-center">
+                <img src={preview.card.image} alt={preview.card.name} className="w-full h-full object-contain" />
+              </div>
+            </div>
+
+            <div className="md:col-span-2 flex flex-col sm:flex-row gap-3">
+              <button
+                onClick={handleConfirm}
+                className="flex-1 px-4 py-2 bg-green-600 hover:bg-green-700 rounded-lg transition-colors"
+              >
+                Use this style for the full deck
+              </button>
+              <button
+                onClick={handleReset}
+                className="flex-1 px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded-lg transition-colors"
+              >
+                Try a different preview
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a style preview flow that generates a back cover and random sample card before committing to a full deck
- store the confirmed prompt/back cover and update the batch generator UI to produce only the remaining cards
- adjust batch generation logic to reuse existing images, report progress correctly, and tweak messaging for the new flow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e53b4770b88332bbffc604913d0c28