### PR TITLE
Use GEMINI_API_KEY environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A React application for generating visual assets for tarot card reading apps usi
 - ✏️ **Individual Card Editing**: Select any card and provide edit instructions to refine it
 - 🔄 **Version Comparison**: Compare old and new versions side-by-side before choosing
 - 💾 **Local Storage**: All images and state are saved in your browser's localStorage
-- 🔑 **Secure API Key Management**: API key stored securely in browser
+- 🔑 **Secure API Key Management**: API key loaded automatically from environment variables
 
 ## Getting Started
 
@@ -25,17 +25,17 @@ A React application for generating visual assets for tarot card reading apps usi
    npm install
    ```
 
-2. Start the development server:
+2. Create a `.env` file (or configure your hosting provider's secrets) with your Gemini key. The application reads from `GEMINI_API_KEY` (or Vite's `VITE_GEMINI_API_KEY` during local development), so add:
+   ```bash
+   GEMINI_API_KEY=your-key-here
+   ```
+
+3. Start the development server:
    ```bash
    npm run dev
    ```
 
-3. Open your browser to the URL shown in the terminal (usually http://localhost:5173)
-
-### First Time Setup
-
-1. Enter your Gemini API key in the "API Configuration" section
-2. The key will be saved securely in your browser
+4. Open your browser to the URL shown in the terminal (usually http://localhost:5173)
 
 ## How to Use
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,9 +6,10 @@ import CardGrid from './components/CardGrid'
 import CardEditor from './components/CardEditor'
 import ComparisonDialog from './components/ComparisonDialog'
 import { loadState, saveState } from './services/localStorage'
+import { getConfiguredApiKey } from './services/geminiApi'
 
 function App() {
-  const [apiKey, setApiKey] = useState('')
+  const apiKey = getConfiguredApiKey()
   const [backCover, setBackCover] = useState(null)
   const [cards, setCards] = useState([])
   const [selectedCard, setSelectedCard] = useState(null)
@@ -16,18 +17,13 @@ function App() {
 
   useEffect(() => {
     const state = loadState()
-    if (state.apiKey) setApiKey(state.apiKey)
     if (state.backCover) setBackCover(state.backCover)
     if (state.cards) setCards(state.cards)
   }, [])
 
   useEffect(() => {
-    saveState({ apiKey, backCover, cards })
-  }, [apiKey, backCover, cards])
-
-  const handleApiKeyChange = (key) => {
-    setApiKey(key)
-  }
+    saveState({ backCover, cards })
+  }, [backCover, cards])
 
   const handleBackCoverGenerated = (imageData) => {
     setBackCover(imageData)
@@ -77,18 +73,16 @@ function App() {
           Tarot Card Visual Asset Generator
         </h1>
 
-        <ApiKeySettings apiKey={apiKey} onApiKeyChange={handleApiKeyChange} />
+        <ApiKeySettings apiKey={apiKey} />
 
         {apiKey && (
           <>
             <BackCoverGenerator
-              apiKey={apiKey}
               currentBackCover={backCover}
               onBackCoverGenerated={handleBackCoverGenerated}
             />
 
             <BatchGenerator
-              apiKey={apiKey}
               onBatchGenerated={handleBatchGenerated}
               onCardGenerated={handleCardGenerated}
             />
@@ -102,7 +96,6 @@ function App() {
             {selectedCard && (
               <CardEditor
                 card={selectedCard}
-                apiKey={apiKey}
                 onClose={() => setSelectedCard(null)}
                 onImageGenerated={handleCardEdit}
               />

--- a/src/components/ApiKeySettings.jsx
+++ b/src/components/ApiKeySettings.jsx
@@ -1,95 +1,66 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
-export default function ApiKeySettings({ apiKey, onApiKeyChange }) {
-  const [isEditing, setIsEditing] = useState(!apiKey)
-  const [tempKey, setTempKey] = useState(apiKey || '')
+export default function ApiKeySettings({ apiKey }) {
   const [showKey, setShowKey] = useState(false)
 
-  const handleSave = () => {
-    if (tempKey.trim()) {
-      onApiKeyChange(tempKey.trim())
-      setIsEditing(false)
-    }
-  }
-
-  const handleCancel = () => {
-    setTempKey(apiKey || '')
-    setIsEditing(false)
-  }
-
-  const maskedKey = apiKey ? `${apiKey.slice(0, 8)}...${apiKey.slice(-4)}` : ''
+  const displayKey = useMemo(() => {
+    if (!apiKey) return 'Not configured'
+    if (showKey) return apiKey
+    if (apiKey.length <= 12) return apiKey
+    return `${apiKey.slice(0, 8)}...${apiKey.slice(-4)}`
+  }, [apiKey, showKey])
 
   return (
     <div className="mb-8 p-6 bg-gray-800 rounded-lg border border-gray-700">
       <h2 className="text-xl font-semibold mb-4 text-purple-400">API Configuration</h2>
 
-      {!isEditing ? (
+      <div className="space-y-4">
         <div className="flex items-center gap-4">
           <div className="flex-1">
             <p className="text-sm text-gray-400 mb-1">Gemini API Key</p>
-            <p className="font-mono text-gray-200">{maskedKey}</p>
+            <p className="font-mono text-gray-200 break-all">{displayKey}</p>
           </div>
           <button
-            onClick={() => setIsEditing(true)}
-            className="px-4 py-2 bg-purple-600 hover:bg-purple-700 rounded-lg transition-colors"
+            type="button"
+            onClick={() => setShowKey(!showKey)}
+            disabled={!apiKey}
+            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-700/50 disabled:text-gray-500 rounded-lg transition-colors"
           >
-            Edit
+            {showKey ? 'Hide' : 'Show'}
           </button>
         </div>
-      ) : (
-        <div className="space-y-4">
-          <div>
-            <label className="block text-sm text-gray-400 mb-2">
-              Enter your Gemini API Key
-            </label>
-            <div className="flex gap-2">
-              <input
-                type={showKey ? 'text' : 'password'}
-                value={tempKey}
-                onChange={(e) => setTempKey(e.target.value)}
-                placeholder="AIza..."
-                className="flex-1 px-4 py-2 bg-gray-900 border border-gray-600 rounded-lg focus:outline-none focus:border-purple-500 text-white"
-              />
-              <button
-                onClick={() => setShowKey(!showKey)}
-                className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded-lg transition-colors"
-              >
-                {showKey ? '👁️' : '👁️‍🗨️'}
-              </button>
-            </div>
-          </div>
 
-          <div className="flex gap-2">
-            <button
-              onClick={handleSave}
-              disabled={!tempKey.trim()}
-              className="px-4 py-2 bg-purple-600 hover:bg-purple-700 disabled:bg-gray-600 disabled:cursor-not-allowed rounded-lg transition-colors"
-            >
-              Save
-            </button>
-            {apiKey && (
-              <button
-                onClick={handleCancel}
-                className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded-lg transition-colors"
-              >
-                Cancel
-              </button>
-            )}
+        {apiKey ? (
+          <div className="p-4 bg-green-900/20 border border-green-700 rounded-lg text-sm text-green-300">
+            <p className="font-semibold">Environment key detected ✅</p>
+            <p className="mt-1 text-green-200/80">
+              The application will use the Gemini API key provided via environment variables. Update the secret to change the key.
+            </p>
           </div>
+        ) : (
+          <div className="p-4 bg-red-900/30 border border-red-700 rounded-lg text-sm text-red-300">
+            <p className="font-semibold">Environment key missing ⚠️</p>
+            <p className="mt-1 text-red-200/80">
+              Set an environment variable named{' '}
+              <code className="bg-red-800/40 px-1 rounded">GEMINI_API_KEY</code> (or Vite-compatible{' '}
+              <code className="bg-red-800/40 px-1 rounded">VITE_GEMINI_API_KEY</code>) before running the app.
+            </p>
+          </div>
+        )}
 
-          <p className="text-xs text-gray-500">
-            Get your API key from{' '}
-            <a
-              href="https://aistudio.google.com/app/apikey"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-purple-400 hover:text-purple-300 underline"
-            >
-              Google AI Studio
-            </a>
-          </p>
-        </div>
-      )}
+        <p className="text-xs text-gray-500">
+          Manage your Gemini API keys from{' '}
+          <a
+            href="https://aistudio.google.com/app/apikey"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-purple-400 hover:text-purple-300 underline"
+          >
+            Google AI Studio
+          </a>
+          .
+        </p>
+      </div>
     </div>
   )
 }

--- a/src/components/BackCoverGenerator.jsx
+++ b/src/components/BackCoverGenerator.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { generateImage } from '../services/geminiApi'
 
-export default function BackCoverGenerator({ apiKey, currentBackCover, onBackCoverGenerated }) {
+export default function BackCoverGenerator({ currentBackCover, onBackCoverGenerated }) {
   const [prompt, setPrompt] = useState('')
   const [isGenerating, setIsGenerating] = useState(false)
   const [error, setError] = useState(null)
@@ -14,7 +14,6 @@ export default function BackCoverGenerator({ apiKey, currentBackCover, onBackCov
 
     try {
       const imageDataUrl = await generateImage(
-        apiKey,
         `Create a tarot card back cover design. ${prompt}. The design should be mystical, ornate, and symmetrical, suitable for the back of all tarot cards in a deck. IMPORTANT: Create this as a vertical portrait image with a 2:3 aspect ratio (width:height). The entire design should fit within this format without any cropping.`
       )
       onBackCoverGenerated(imageDataUrl)

--- a/src/components/BatchGenerator.jsx
+++ b/src/components/BatchGenerator.jsx
@@ -2,7 +2,7 @@ import { useState, useRef } from 'react'
 import { batchGenerateCards } from '../services/geminiApi'
 import { initializeCards } from '../data/tarotCards'
 
-export default function BatchGenerator({ apiKey, onBatchGenerated, onCardGenerated }) {
+export default function BatchGenerator({ onBatchGenerated, onCardGenerated }) {
   const [prompt, setPrompt] = useState('')
   const [isGenerating, setIsGenerating] = useState(false)
   const [progress, setProgress] = useState({ current: 0, total: 0 })
@@ -28,8 +28,7 @@ export default function BatchGenerator({ apiKey, onBatchGenerated, onCardGenerat
       // Initialize cards immediately to show placeholders
       onBatchGenerated(cards)
 
-      const generatedCards = await batchGenerateCards(
-        apiKey,
+      await batchGenerateCards(
         cards,
         prompt,
         (current, total) => setProgress({ current, total }),

--- a/src/components/CardEditor.jsx
+++ b/src/components/CardEditor.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { generateImage, editImage } from '../services/geminiApi'
 
-export default function CardEditor({ card, apiKey, onClose, onImageGenerated }) {
+export default function CardEditor({ card, onClose, onImageGenerated }) {
   const [editPrompt, setEditPrompt] = useState('')
   const [isGenerating, setIsGenerating] = useState(false)
   const [error, setError] = useState(null)
@@ -16,11 +16,11 @@ export default function CardEditor({ card, apiKey, onClose, onImageGenerated }) 
       let newImage
       if (card.image) {
         // Edit existing image
-        newImage = await editImage(apiKey, card.image, editPrompt)
+        newImage = await editImage(card.image, editPrompt)
       } else {
         // Generate new image from scratch
         const fullPrompt = `Create a tarot card illustration for "${card.name}". ${editPrompt}. The card should be vertically oriented with mystical and symbolic imagery. IMPORTANT: Create this as a vertical portrait image with a 2:3 aspect ratio (width:height). The entire design should fit within this format without any cropping.`
-        newImage = await generateImage(apiKey, fullPrompt)
+        newImage = await generateImage(fullPrompt)
       }
       onImageGenerated(card.id, newImage)
       setEditPrompt('')

--- a/src/services/localStorage.js
+++ b/src/services/localStorage.js
@@ -23,7 +23,8 @@ export function loadState() {
  */
 export function saveState(state) {
   try {
-    const serializedState = JSON.stringify(state)
+    const { apiKey, ...rest } = state || {}
+    const serializedState = JSON.stringify(rest)
     localStorage.setItem(STORAGE_KEY, serializedState)
   } catch (error) {
     console.error('Error saving state to localStorage:', error)
@@ -41,27 +42,3 @@ export function clearState() {
   }
 }
 
-/**
- * Save API key separately for security
- * @param {string} apiKey - The API key to save
- */
-export function saveApiKey(apiKey) {
-  try {
-    localStorage.setItem('tarot-api-key', apiKey)
-  } catch (error) {
-    console.error('Error saving API key:', error)
-  }
-}
-
-/**
- * Load API key
- * @returns {string|null} - The saved API key or null
- */
-export function loadApiKey() {
-  try {
-    return localStorage.getItem('tarot-api-key')
-  } catch (error) {
-    console.error('Error loading API key:', error)
-    return null
-  }
-}


### PR DESCRIPTION
## Summary
- limit Gemini API key detection to the GEMINI_API_KEY (and Vite variant) secret names
- update the UI copy to tell users to set GEMINI_API_KEY or VITE_GEMINI_API_KEY
- adjust the README environment instructions to default to GEMINI_API_KEY

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e53c7887708332a3cd2390dd93cc47