### PR TITLE
Load Gemini API key from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A React application for generating visual assets for tarot card reading apps usi
 - ✏️ **Individual Card Editing**: Select any card and provide edit instructions to refine it
 - 🔄 **Version Comparison**: Compare old and new versions side-by-side before choosing
 - 💾 **Local Storage**: All images and state are saved in your browser's localStorage
-- 🔑 **Secure API Key Management**: API key stored securely in browser
+- 🔑 **Secure API Key Management**: API key loaded from environment variables
 
 ## Getting Started
 
@@ -17,6 +17,7 @@ A React application for generating visual assets for tarot card reading apps usi
 
 - Node.js (v14 or higher)
 - A Gemini API key from [Google AI Studio](https://aistudio.google.com/app/apikey)
+- The `GEMINI_API_KEY` environment variable set before running the app
 
 ### Installation
 
@@ -34,8 +35,7 @@ A React application for generating visual assets for tarot card reading apps usi
 
 ### First Time Setup
 
-1. Enter your Gemini API key in the "API Configuration" section
-2. The key will be saved securely in your browser
+Set the `GEMINI_API_KEY` environment variable before starting the development server.
 
 ## How to Use
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,7 @@ import { initializeCards } from './data/tarotCards'
 import { loadState, saveState } from './services/localStorage'
 
 function App() {
-  const [apiKey, setApiKey] = useState('')
+  const envApiKey = import.meta.env.GEMINI_API_KEY || ''
   const [backCover, setBackCover] = useState(null)
   const [cards, setCards] = useState([])
   const [selectedCard, setSelectedCard] = useState(null)
@@ -19,7 +19,6 @@ function App() {
 
   useEffect(() => {
     const state = loadState()
-    if (state.apiKey) setApiKey(state.apiKey)
     if (state.backCover) setBackCover(state.backCover)
     if (state.cards) setCards(state.cards)
     if (state.stylePrompt) setStylePrompt(state.stylePrompt)
@@ -27,12 +26,8 @@ function App() {
   }, [])
 
   useEffect(() => {
-    saveState({ apiKey, backCover, cards, stylePrompt, hasConfirmedStyle })
-  }, [apiKey, backCover, cards, stylePrompt, hasConfirmedStyle])
-
-  const handleApiKeyChange = (key) => {
-    setApiKey(key)
-  }
+    saveState({ backCover, cards, stylePrompt, hasConfirmedStyle })
+  }, [backCover, cards, stylePrompt, hasConfirmedStyle])
 
   const handleBatchGenerated = (generatedCards) => {
     setCards(generatedCards)
@@ -113,13 +108,13 @@ function App() {
           Tarot Card Visual Asset Generator
         </h1>
 
-        <ApiKeySettings apiKey={apiKey} onApiKeyChange={handleApiKeyChange} />
+        <ApiKeySettings apiKey={envApiKey} />
 
-        {apiKey && (
+        {envApiKey ? (
           <>
             {!hasConfirmedStyle ? (
               <StylePreviewGenerator
-                apiKey={apiKey}
+                apiKey={envApiKey}
                 onPreviewConfirmed={handlePreviewConfirmed}
               />
             ) : (
@@ -162,7 +157,7 @@ function App() {
 
             {hasConfirmedStyle && (
               <BatchGenerator
-                apiKey={apiKey}
+                apiKey={envApiKey}
                 prompt={stylePrompt}
                 cards={cards}
                 onBatchGenerated={handleBatchGenerated}
@@ -179,7 +174,7 @@ function App() {
             {selectedCard && (
               <CardEditor
                 card={selectedCard}
-                apiKey={apiKey}
+                apiKey={envApiKey}
                 onClose={() => setSelectedCard(null)}
                 onImageGenerated={handleCardEdit}
               />
@@ -193,7 +188,7 @@ function App() {
               />
             )}
           </>
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/src/components/ApiKeySettings.jsx
+++ b/src/components/ApiKeySettings.jsx
@@ -1,84 +1,28 @@
-import { useState } from 'react'
-
-export default function ApiKeySettings({ apiKey, onApiKeyChange }) {
-  const [isEditing, setIsEditing] = useState(!apiKey)
-  const [tempKey, setTempKey] = useState(apiKey || '')
-  const [showKey, setShowKey] = useState(false)
-
-  const handleSave = () => {
-    if (tempKey.trim()) {
-      onApiKeyChange(tempKey.trim())
-      setIsEditing(false)
-    }
-  }
-
-  const handleCancel = () => {
-    setTempKey(apiKey || '')
-    setIsEditing(false)
-  }
-
-  const maskedKey = apiKey ? `${apiKey.slice(0, 8)}...${apiKey.slice(-4)}` : ''
+export default function ApiKeySettings({ apiKey }) {
+  const maskedKey = apiKey ? `${apiKey.slice(0, 8)}...${apiKey.slice(-4)}` : null
 
   return (
     <div className="mb-8 p-6 bg-gray-800 rounded-lg border border-gray-700">
       <h2 className="text-xl font-semibold mb-4 text-purple-400">API Configuration</h2>
 
-      {!isEditing ? (
-        <div className="flex items-center gap-4">
-          <div className="flex-1">
-            <p className="text-sm text-gray-400 mb-1">Gemini API Key</p>
-            <p className="font-mono text-gray-200">{maskedKey}</p>
+      {apiKey ? (
+        <div className="space-y-2">
+          <p className="text-sm text-gray-300">
+            The Gemini API key is automatically loaded from the <code>GEMINI_API_KEY</code> environment variable.
+          </p>
+          <div>
+            <p className="text-sm text-gray-400 mb-1">Active API key</p>
+            <p className="font-mono text-gray-200 break-all">{maskedKey}</p>
           </div>
-          <button
-            onClick={() => setIsEditing(true)}
-            className="px-4 py-2 bg-purple-600 hover:bg-purple-700 rounded-lg transition-colors"
-          >
-            Edit
-          </button>
         </div>
       ) : (
-        <div className="space-y-4">
-          <div>
-            <label className="block text-sm text-gray-400 mb-2">
-              Enter your Gemini API Key
-            </label>
-            <div className="flex gap-2">
-              <input
-                type={showKey ? 'text' : 'password'}
-                value={tempKey}
-                onChange={(e) => setTempKey(e.target.value)}
-                placeholder="AIza..."
-                className="flex-1 px-4 py-2 bg-gray-900 border border-gray-600 rounded-lg focus:outline-none focus:border-purple-500 text-white"
-              />
-              <button
-                onClick={() => setShowKey(!showKey)}
-                className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded-lg transition-colors"
-              >
-                {showKey ? '👁️' : '👁️‍🗨️'}
-              </button>
-            </div>
-          </div>
-
-          <div className="flex gap-2">
-            <button
-              onClick={handleSave}
-              disabled={!tempKey.trim()}
-              className="px-4 py-2 bg-purple-600 hover:bg-purple-700 disabled:bg-gray-600 disabled:cursor-not-allowed rounded-lg transition-colors"
-            >
-              Save
-            </button>
-            {apiKey && (
-              <button
-                onClick={handleCancel}
-                className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded-lg transition-colors"
-              >
-                Cancel
-              </button>
-            )}
-          </div>
-
+        <div className="space-y-2">
+          <p className="text-sm text-red-300 font-semibold">No API key detected.</p>
+          <p className="text-sm text-gray-300">
+            Set the <code>GEMINI_API_KEY</code> environment variable before starting the app to enable image generation.
+          </p>
           <p className="text-xs text-gray-500">
-            Get your API key from{' '}
+            API keys can be created in{' '}
             <a
               href="https://aistudio.google.com/app/apikey"
               target="_blank"
@@ -87,6 +31,7 @@ export default function ApiKeySettings({ apiKey, onApiKeyChange }) {
             >
               Google AI Studio
             </a>
+            .
           </p>
         </div>
       )}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,13 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
-  plugins: [react()],
-})
+export default ({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+
+  return defineConfig({
+    plugins: [react()],
+    define: {
+      'import.meta.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- load the Gemini API key from the GEMINI_API_KEY environment variable via Vite configuration
- simplify the API configuration UI to display environment status instead of collecting user input
- document the new environment variable requirement in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e554537d1c833297856ad789e1ef18